### PR TITLE
All-in-one onboarding

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -12,20 +12,8 @@ Prerequisites:
 ### Get started
 
  
-1. Clone this repo and navigate to the repo folder. Run `composer create-project --prefer-dist laravel/laravel my-app`
-4. Run `mv my-app/* my-app/.* ./ && rm -rf my-app`
-5. Change the values in your `.env` to the values below:
-
-```
-DB_CONNECTION=mysql
-DB_HOST=laravel_db
-DB_PORT=3306
-DB_DATABASE=laravel
-DB_USERNAME=laravel_user
-DB_PASSWORD=myStrongPassword1234
-```
- 
-The last step, run `docker-compose up`
+1. Clone this repo and navigate to the repo folder. Run `bash ./new_project.sh`
+2. Run `docker-compose up`
 
 When you run `docker ps`, you should see your service running locally at `http://localhost:9000`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,7 @@
-FROM php:7.3-apache
-RUN apt-get update -yqq && \
-    apt-get install -y apt-utils zip unzip && \
-    apt-get install -y nano && \
-    apt-get install -y libzip-dev libpq-dev  && \
-    apt-get install -y libxml2-dev && \
-    apt-get install -y libmcrypt-dev && \
-    a2enmod rewrite && \
-    docker-php-ext-install pdo && \
-    docker-php-ext-install pdo_mysql && \
-    docker-php-ext-install mysqli && \
-    docker-php-ext-configure zip --with-libzip && \
-    docker-php-ext-install zip && \
-    docker-php-ext-install hash && \
-    docker-php-ext-install mbstring && \
-    docker-php-ext-install bcmath && \
-    docker-php-ext-install json && \
-    docker-php-ext-install tokenizer && \
-    #apt-get install supervisor -y && \
-    rm -rf /var/lib/apt/lists/*
+FROM carter-laravel-starter:latest
 
-ENV APACHE_DOCUMENT_ROOT=/var/www/app/public
-RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
-RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
-
-COPY composer.json /var/www/app/
-WORKDIR /var/www/app
-RUN php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer
+COPY --chown=www-data:www-data my-app/composer.json my-app/composer.lock ./
 RUN composer install --prefer-dist --no-autoloader
-COPY . /var/www/app
+
+COPY --chown=www-data:www-data my-app/* .
 RUN composer dump-autoload --optimize
-RUN chown -R www-data:www-data \
-        /var/www/app/storage \
-        /var/www/app/bootstrap/cache
-EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM carter-laravel-starter:latest
 
-COPY --chown=www-data:www-data my-app/composer.json my-app/composer.lock ./
+COPY --chown=www-data:www-data composer.json composer.lock ./
 RUN composer install --prefer-dist --no-autoloader
 
-COPY --chown=www-data:www-data my-app/* .
+COPY --chown=www-data:www-data . .
 RUN composer dump-autoload --optimize

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -1,0 +1,30 @@
+FROM php:7.3-apache
+
+RUN apt-get update -yqq && \
+    apt-get install -y \
+        apt-utils zip unzip \
+        nano \
+        libzip-dev libpq-dev  \
+        libxml2-dev \
+        libmcrypt-dev \
+    && a2enmod rewrite && \
+    docker-php-ext-install pdo && \
+    docker-php-ext-install pdo_mysql && \
+    docker-php-ext-install mysqli && \
+    docker-php-ext-configure zip --with-libzip && \
+    docker-php-ext-install zip && \
+    docker-php-ext-install hash && \
+    docker-php-ext-install mbstring && \
+    docker-php-ext-install bcmath && \
+    docker-php-ext-install json && \
+    docker-php-ext-install tokenizer && \
+    #apt-get install supervisor -y && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV APACHE_DOCUMENT_ROOT=/var/www/app/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+RUN php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer
+WORKDIR /var/www/app
+EXPOSE 80

--- a/new_project.sh
+++ b/new_project.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly run="${1:-}"
+
+should_run=false
+if [ "${run}" == "run" ]; then
+    should_run=true
+fi
+
+build_container() {
+    docker build -f Dockerfile.common -t carter-laravel-starter .
+    docker run -it --rm -v $(pwd):/var/www/app carter-laravel-starter:latest /bin/bash new_project.sh run
+}
+
+run_container() {
+    local -r destination=$(mktemp -d)
+
+    composer create-project --prefer-dist laravel/laravel "${destination}"
+
+    sed -i "s/^DB_CONNECTION=.*/DB_CONNECTION=mysql/g" "${destination}/.env"
+    sed -i "s/^DB_HOST=.*/DB_HOST=laravel_db/g" "${destination}/.env"
+    sed -i "s/^DB_PORT=.*/DB_PORT=3306/g" "${destination}/.env"
+    sed -i "s/^DB_DATABASE=.*/DB_DATABASE=laravel/g" "${destination}/.env"
+    sed -i "s/^DB_USERNAME=.*/DB_USERNAME=laravel_user/g" "${destination}/.env"
+    sed -i "s/^DB_PASSWORD=.*/DB_PASSWORD=myStrongPassword1234/g" "${destination}/.env"
+
+    cp -rT "${destination}" .
+
+    echo
+    echo 'Project created successfully! You can now run it with "docker-compose up"'
+}
+
+if $should_run; then
+    run_container
+else
+    build_container
+fi


### PR DESCRIPTION
I did not test this on windows so there may be some editing of the `new_project.sh` script needed for that environment.

This automates the initial project generation, and removes the local php/composer dependency except for the fact that I didn't set the Dockerfile `CMD` because I don't actually know how composer projects are typically run. If it just runs through standard `apache` then its good to go.